### PR TITLE
Remove use of git-lfs for handling database

### DIFF
--- a/data/bbsforecasting.sqlite
+++ b/data/bbsforecasting.sqlite
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48aa76221074cfee91170351b1e39d11ba6f61056cafc77743f525ef33035dab
-size 842805248


### PR DESCRIPTION
git-lfs was difficult to work with due to the no public forks issue:
https://medium.com/@megastep/github-s-large-file-storage-is-no-panacea-for-open-source-quite-the-opposite-12c0e16a9a91

This removes the intermediate database from version control. For the moment
the user will need to generate it themselves (which in most cases would be the
case outside of the lab anyway). For in-house purposes I've put a copy of the T-drive.