### PR TITLE
Add a check for no PRISM files being present

### DIFF
--- a/get_prism_data.R
+++ b/get_prism_data.R
@@ -54,6 +54,7 @@ download_prism=function(){
 #########################################################
 check_if_prism_files_present=function(prism_ls, years){
   #Extract out all the variable names and dates
+  if (length(prism_ls$files) == 0){return(FALSE)}
   prism_ls = prism_ls %>%
     rowwise() %>%
     mutate(var=strsplit(files, '_')[[1]][2], yearMonth=strsplit(files, '_')[[1]][5]) %>%


### PR DESCRIPTION
check_if_prism_files_present needs to check if there are no PRISM files
present at all to avoid erroring if the directory is empty.