### PR TITLE
collect whole ndvi series

### DIFF
--- a/R/get_ndvi_data.R
+++ b/R/get_ndvi_data.R
@@ -118,7 +118,7 @@ get_bbs_gimms_ndvi = function(
   dir.create(gimms_folder, showWarnings = FALSE, recursive = TRUE)
 
   if('gimms_ndvi_bbs_data' %in% src_tbls(database)){
-    return(collect(tbl(database, sql('SELECT * from gimms_ndvi_bbs_data'))))
+    return(collect(tbl(database, sql('SELECT * from gimms_ndvi_bbs_data')), n = Inf))
   } else {
     print('Gimms NDVI bbs data not found, processing from scratch')
 


### PR DESCRIPTION
The dev version of dplyr apparently only gets the first hundred thousand rows by default, and throws a warning.  This fixes it.