### PR TITLE
Automate package installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,23 @@
+name: bbs-forecasting
+channels:
+  - r
+dependencies:
+  - r
+  - python=3
+  - jupyter
+  - r-dplyr
+  - r-forecast
+  - r-devtools
+  - r-ggplot2
+  - r-hmisc
+  - r-tidyr
+  - r-mgcv
+  - r-sp
+  - r-raster
+  - r-maptools
+  - r-doparallel
+  - r-stringr
+  - netcdf4
+  - gdal
+  - r-irkernel
+  - r-rcurl

--- a/install-packages.R
+++ b/install-packages.R
@@ -1,0 +1,20 @@
+# Install pacman if it isn't already installed
+
+if ("pacman" %in% rownames(installed.packages()) == FALSE) install.packages("pacman")
+
+
+# Install analysis packages using pacman
+
+pacman::p_load(dplyr, forecast, ggplot2, Hmisc, tidyr, mgcv, sp, raster,
+               maptools, doParallel, stringr, RCurl, roxygen2,
+	       broom, devtools, doParallel, dplyr, forecast, ggplot2,
+	       gimms, Hmisc, maptools, mgcv, prism, raster, stringr, sp,
+	       tidyr, rgdal, rgeos, DBI, RSQLite)
+pacman::p_load_gh('seantuck12/MODISTools', 'ropensci/ecoretriever')
+
+
+# Install IRkernal packages and spec
+
+pacman::p_load(repr, pbdZMQ)
+pacman::p_load_gh('IRkernel/IRdisplay', 'IRkernel/IRkernel')
+IRkernel::installspec()


### PR DESCRIPTION
This attempts to make the fairly advanced and package heavy stack easier to setup.

1. Add install-packages.R to run pacman to install any additional packages
2. Trigger install.packages.R from the notebook
3. Start development of an environment.yml file for installing R and as many
   packages as possible via conda. This is still in development. It works
   but doesn't play well some of the more complex packages installed directly
   from R yet.