### PR TITLE
include gimms version number 0

### DIFF
--- a/R/get_ndvi_data.R
+++ b/R/get_ndvi_data.R
@@ -12,7 +12,7 @@
 #Returns a list of files to download, which may be length 0.
 ##################################################
 get_gimms_download_list=function(gimms_folder = './data/gimms_ndvi/'){
-  available_files_download_path=gimms::updateInventory()
+  available_files_download_path=gimms::updateInventory(version=0)
   available_files_name=basename(available_files_download_path)
 
   files_present=list.files(gimms_folder)


### PR DESCRIPTION
The gimms package was recently updated to include version 1 of the gimms dataset and set version 1 as the default. Version 1 changes the file structure so most of get_ndvi_data will have to be redone if we switch to it. This will stick to version 0 for now.