### PR TITLE
Extend all env data

### DIFF
--- a/R/forecast-bbs-core.R
+++ b/R/forecast-bbs-core.R
@@ -204,7 +204,7 @@ get_route_data <- function(){
 #' @param timeframe Either 'past' or 'future' for 1981-2013 or 2014-2050, respectively. 
 #' @export
 #' @importFrom dplyr "%>%" filter group_by summarise ungroup inner_join full_join
-#' @importFrom tidyr gather
+#' @importFrom tidyr gather spread
 
 get_env_data <- function(timeframe = 'past'){
   ndvi_data_raw <- get_bbs_gimms_ndvi()

--- a/R/forecast-bbs-core.R
+++ b/R/forecast-bbs-core.R
@@ -235,7 +235,7 @@ get_env_data <- function(timeframe = 'past'){
   #If projecting forward, use NDVI averages for future NDVI values, and use
   #CMIP5 data for bioclim values
   if(timeframe == 'future') {
-    ndvi_long_term_averges = ndvi_data %>%
+    ndvi_long_term_averages = ndvi_data %>%
       filter(year %in% 2000:2013) %>%
       gather(season,value, -site_id, -year) %>%
       group_by(site_id, season) %>%
@@ -245,7 +245,7 @@ get_env_data <- function(timeframe = 'past'){
     all_sites = unique(ndvi_data$site_id)
     
     ndvi_data = expand.grid(site_id = all_sites, year=2014:2050) %>%
-      left_join(ndvi_long_term_averges, by='site_id') %>%
+      left_join(ndvi_long_term_averages, by='site_id') %>%
       spread(season, value)
     
     bioclim_data = get_bioclim_data(source='cmip5') %>%

--- a/man/get_env_data.Rd
+++ b/man/get_env_data.Rd
@@ -2,10 +2,13 @@
 % Please edit documentation in R/forecast-bbs-core.R
 \name{get_env_data}
 \alias{get_env_data}
-\title{Get combined environmental data}
+\title{#' Master function for acquiring all environmental in a single table}
 \usage{
-get_env_data()
+get_env_data(timeframe = "past")
+}
+\arguments{
+\item{timeframe}{Either 'past' or 'future' for 1981-2013 or 2014-2050, respectively.}
 }
 \description{
-Master function for acquiring all environmental in a single table
+#' Master function for acquiring all environmental in a single table
 }


### PR DESCRIPTION
I updated `get_env_data()` to get either past data (1981-2013) or future data(2014-2050). Past is the default so everything works the same with other data functions, using `get_env_data(timeframe='future')` now returns data for 2014-2050. 