### PR TITLE
actually fix ridgeway citation

### DIFF
--- a/manuscript/refs.bib
+++ b/manuscript/refs.bib
@@ -698,7 +698,7 @@ year = {2013}
 
 @Manual{gbm,
   title = {{gbm}: Generalized Boosted Regression Models},
-  author = {Greg Ridgeway with contributions from others},
+  author = {{Ridgeway, G., with contributions from others}},
   year = {2017},
   note = {R package version 2.1.3},
   url = {https://CRAN.R-project.org/package=gbm},


### PR DESCRIPTION
{{{More curly braces}}}

Now it reads 

> Ridgeway, G. with contributions from others. 2017. gbm: Generalized boosted regresion models.