### PR TITLE
Editor comments

### DIFF
--- a/manuscript/draft.Rmd
+++ b/manuscript/draft.Rmd
@@ -305,8 +305,8 @@ $$y_t = \mu + \epsilon_t.$$
 
 Predictions from the "average" model are thus centered on $\mu$, which could
 either be the mean of the raw training richness values, or an output from the
-observer model.  This model's confidence intervals have a constant width that
-depends on the standard deviation of $\epsilon$, which can either be the
+observer model. The confidence iterval width in this model is constant and a 
+consequence of the standard deviation $\epsilon$, which can either be the
 standard deviation of the raw training richness values, or
 $\sigma^\mathrm{residual}$ from the observer model; see supplement).
 
@@ -332,7 +332,7 @@ function in the package `forecast`; @forecast1] to represent an array of
 different time-series modeling approaches. These models can include an
 autoregressive component (as in the "naive" model, but with the possibility of
 longer-term dependencies in the underlying process), a moving average component
-(where the noise can have serial autocorrelation) and an
+(where the noise may be serially autocorrelation) and an
 integration/differencing component (so that the analysis could be performed on
 sequential differences of the raw data, accommodating more complex patterns
 including trends). The `auto.arima` function chooses whether to include each of
@@ -350,7 +350,7 @@ stacking individual species distribution models; and joint species distribution
 models (JSDMs). Following the standard approach, site-level random effects were
 not included in these models as predictors, meaning that this approach
 implicitly assumes that two sites with identical Bioclim, elevation, and NDVI
-values should have identical richness distributions. As above, we included
+values will have identical richness distributions. As above, we included
 observer effects and the associated uncertainty by running these models 500
 times (once per MCMC sample).
 
@@ -506,7 +506,7 @@ Most models produced confidence intervals that were too narrow, indicating
 overconfident predictions (Figure 5C). The random forest-based SDM stack was the
 most overconfident model, with only `r numbers$rf_coverage_pct`% of observations
 falling inside its 95% confidence intervals. This stacked SDM's narrow
-predictive distribution caused it to have notably higher deviance (Figure 5B)
+predictive distribution caused notably greater deviance (Figure 5B)
 than the next-worst model, even though its point estimates were not unusually
 bad in terms of RMSE (5A). As discussed elsewhere [@harris2015], this
 overconfidence is a product of the assumption in stacked SDMs that errors in the
@@ -556,12 +556,12 @@ Naive baseline, however.](../figures/obs_arrows.png)
 
 Forecasting is an emerging imperative in ecology; as such, the field needs to
 develop and follow best practices for conducting and evaluating ecological
-forecasts [@clark2001]. We have used a number of these practices (Box 1) in a
+forecasts [@clark2001]. We used a number of these practices (Box 1) in a
 single study that builds and evaluates forecasts of biodiversity in the form of
 species richness. The results of this effort are both promising and humbling.
 When comparing predictions across sites, many different approaches produce
-reasonable forecasts (Figure 3). If a site is predicted to have a high number of
-species in the future, relative to other sites, it generally does.  However,
+reasonable forecasts (Figure 3). If a site is predicted to have high species
+richness in the future, relative to other sites, it generally does.  However,
 none of the methods evaluated reliably determined how site-level richness
 changes over time (Figure 6), which is generally the stated purpose of these
 forecasts. As a result, baseline models, which did not attempt to anticipate
@@ -574,20 +574,20 @@ The most commonly used methods for forecasting future biodiversity, SDMs and
 macroecological models, both produced worse forecasts than time-series models
 and simple baselines. This weakness suggests that predictions about future
 biodiversity change should be viewed with skepticism unless the underlying
-models have been validated temporally, via hindcasting and comparison with
+models are temporally validated, via hindcasting and comparison with
 simple baselines. Since site-level richness is relatively stable, spatial
-validation is not enough: a model can have high accuracy across spatial
-gradients without being able to predict changes over time. This gap between
-spatial and temporal accuracy is known to be important for species-level
+validation is not enough: a model be accurate across spatial gradients while
+being unable to predict changes over time. This gap between
+spatial and temporal accuracy is important for species-level
 predictions [@rapacciuolo2012; @oedekoven2017]; our results indicate that it is
-substantial for higher-level patterns like richness as well. SDMs' poor temporal
-predictions are particularly sobering, as these models have been one of the main
-foundations for estimates of the predicted loss of biodiversity to climate
-change over the past decade or so [@thomas2004; @thuiller2011; @urban2015]. Our
+substantial for higher-level patterns like richness as well. The poor quality 
+temporal predictions of SDM's are particularly sobering because of their importance
+over the last decade or so for predicting biodiversity loss as a response to 
+climate change [@thomas2004; @thuiller2011; @urban2015]. Our
 results also highlight the importance of comparing multiple modeling approaches
 when conducting ecological forecasts, and in particular, the value of comparing
 results to simple baselines to avoid over-interpreting the information present
-in these forecasts [Box 1]. Disciplines that have more mature forecasting
+in these forecasts [Box 1]. Disciplines with more mature forecasting
 cultures often do this by reporting "forecast skill", i.e., the improvement in
 the forecast relative to a simple baseline [@jolliffe2003]. We recommend
 following the example of @perretti2013 and adopting this approach in future
@@ -605,11 +605,11 @@ values fell outside the stacked SDMs' 95% prediction intervals. Consistent with
 enabled them to avoid this problem. Macroecological models appear to share this
 advantage, while being considerably easier to implement. 
 
-We have only evaluated annual forecasts up to a decade into the future, but
+We only evaluated annual forecasts up to a decade into the future, but
 forecasts are often made with a lead time of 50 years or more. These long-term
 forecasts are difficult to evaluate given the small number of century-scale
 datasets, but are important for understanding changes in biodiversity at some of
-the lead times relevant for conservation and management. Two studies have
+the lead times relevant for conservation and management. Two studies
 assessed models of species richness at longer lead times [@algar2009;
 @distler2015], but the results were not compared to baseline or time-series
 models (in part due to data limitations) making them difficult to compare to our
@@ -674,7 +674,7 @@ introduced by the error in forecasting the environmental conditions that are
 used as predictor variables. In this, and other hindcasting studies, the
 environmental conditions for the "future" are known because the data has already
 been observed. However, in real forecasts the environmental conditions
-themselves have to be predicted, and environmental forecasts will also have
+themselves must be predicted, and environmental forecasts will also have
 uncertainty and bias. Ultimately, ecological forecasts that use environmental
 data will therefore be more uncertain than our current hindcasting efforts, and
 it is important to correctly incorporate this uncertainty into our models
@@ -722,7 +722,7 @@ assessment [@mcgill2012; @dietze2016]. These forecasts should include both
 short-term predictions, which can be assessed quickly, and mid- to long-term
 forecasts, which can help ecologists to assess long time-scale processes and
 determine how far into the future we can successfully forecast [@dietze2016;
-@tredennick2016]. We have openly archived forecasts from all six models through
+@tredennick2016]. We openly archived forecasts from all six models through
 the year 2050 [@zenodoPredict], so that we and others can assess how well they
 perform. We plan to evaluate these forecasts and report the results as each new
 year of BBS data becomes available, and make iterative improvements to the

--- a/manuscript/draft.Rmd
+++ b/manuscript/draft.Rmd
@@ -75,20 +75,20 @@ ecological models capture the key processes governing natural systems
 especially important, due to biodiversity's central role in conservation
 planning and its sensitivity to anthropogenic effects [@cardinale2012;
 @diaz2015; @tilman2017]. High-profile studies forecasting large biodiversity
-declines over the coming decades have played a large role in shaping ecologists'
-priorities [as well as those of policymakers; e.g. @ipcc2014], but it is
-inherently difficult to evaluate such long-term predictions before the projected
-biodiversity declines have occurred.
+declines over the coming decades have played a large role in shaping the
+priorities of ecologists and policymakers [e.g. @ipcc2014], but it is inherently
+difficult to evaluate such long-term predictions prior to the predicted decline
+in diversity.
 
 Previous efforts to predict future patterns of terrestrial species richness, and
 diversity more generally, have focused primarily on building species
 distributions models [SDMs; @thomas2004; @thuiller2011; @urban2015]. In general,
 these models describe individual species' occurrence patterns as functions of
 the environment. Given forecasts for environmental conditions, these models can
-predict where each species will occur in the future. These species-level 
-predictions are then combined ("stacked") to generate forecasts for species 
+predict where each species will occur in the future. These species-level
+predictions are then combined ("stacked") to generate forecasts for species
 richness [e.g. @calabrese2014]. Alternatively, models that directly relate
-spatial patterns of species richness to environment conditions have been
+spatial patterns of species richness to environment conditions are available
 developed and generally perform equivalently to stacked SDMs [@algar2009;
 @distler2015]. This approach is sometimes referred to as "macroecological"
 modeling, because it models the larger-scale pattern (richness) directly
@@ -165,7 +165,7 @@ package [@morris2013; @senyondo2017] and rdataretriever R package
 fixed locations along a 40km route. Here we denote each route as a site and
 summarize richness as the total species observed at all 50 locations in each
 surveyed year. Prior to summarizing the data was filtered to exclude all
-nocturnal, cepuscular, and aquatic species [since these species are not well
+nocturnal, crepuscular, and aquatic species [since these species are not well
 sampled by BBS methods; @hurlbert2005], as well as unidentified species, and
 hybrids. All data from surveys that did not meet BBS quality criteria were also
 excluded.
@@ -202,16 +202,16 @@ than point counts, we used the average value of each environmental variable
 within a 40 km radius of each BBS route's starting point.
 
 **Future environmental projections.** In addition to the analyses presented
-here, we have also generated and archived long term forecasts from 2014-2050.
-This will allow future researchers to assess the performance of our six models
-on longer time horizons as more years of BBS data become available.
-Precipitation and temperature were forecast using the CMIP5 multi-model ensemble
-dataset [@brekke2013]. 37 downscaled model runs [@brekke2013, see Table S1]
-using the RCP6.0 scenario were averaged together to create a single ensemble
-used to calculate the bioclimatic variables for North America. For NDVI, we used
-the per-site average values from 2000-2013 as a simple forecast. For observer
-effects (see below), each site was set to have zero observer bias. The
-predictions have been archived at [@zenodoPredict].
+here, we also generated and archived long term forecasts from 2014-2050. This
+will allow future researchers to assess the performance of our six models on
+longer time horizons as more years of BBS data become available. Precipitation
+and temperature were forecast using the CMIP5 multi-model ensemble dataset
+[@brekke2013]. We averaged 37 downscaled model runs [@brekke2013, see Table S1]
+using the RCP6.0 scenario to create a single ensemble used to calculate the
+bioclimatic variables for North America. For NDVI, we used the per-site average
+values from 2000-2013 as a simple forecast. For observer effects (see below),
+each site was set to zero observer bias. The predictions were archived at
+[@zenodoPredict].
 
 ### Accounting for observer effects
 


### PR DESCRIPTION
These changes are pretty straightforward, I think.  

Thera are a couple of places where I left in the word "have" where the editor suggested omitting it:

>High-profile studies forecasting large biodiversity declines over the coming decades **have** played a large role in shaping the priorities of ecologists and policymakers

and:

>Previous efforts to predict future patterns of terrestrial species richness, and diversity more generally, **have** focused primarily on building species distributions models

We can still remove them if you think going along with the editor would be easier though.
  